### PR TITLE
Add in-app review panel for CSV workflow

### DIFF
--- a/src/pdf_to_access_app.py
+++ b/src/pdf_to_access_app.py
@@ -375,6 +375,11 @@ class App(tk.Tk):
         if not self.review_panel.has_data():
             return False
 
+        if hasattr(self.review_panel, "is_dirty") and not self.review_panel.is_dirty():
+            if show_message:
+                messagebox.showinfo(APP_TITLE, "No review changes to save.")
+            return False
+
         root = Path(self.root_dir.get())
         ensure_dirs(root)
         try:
@@ -399,6 +404,8 @@ class App(tk.Tk):
         log_line(self.logbox, f"Review CSV saved: {path}")
         if show_message:
             messagebox.showinfo(APP_TITLE, f"Review changes saved to:\n{path}")
+        if hasattr(self.review_panel, "mark_clean"):
+            self.review_panel.mark_clean()
         return True
 
     def try_load_existing_review(self) -> None:

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,1 +1,5 @@
 """UI components for the PDF review application."""
+
+from .review_panel import ReviewPanel
+
+__all__ = ["ReviewPanel"]


### PR DESCRIPTION
## Summary
- add a reusable ReviewPanel widget to display and edit review data in-app
- embed the review panel in the main application and refresh/save review state from extraction
- remove the external CSV button and guide users toward in-app review messaging

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e3ca5474908330b153346293492ac7