### PR TITLE
Fix package imports and ensure pytest can run

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,8 @@
+"""Expose the ``src.core`` package as a top-level ``core`` package."""
+from importlib import import_module
+import sys
+
+_pkg = import_module("src.core")
+
+# Replace this module with the implementation from ``src.core``.
+sys.modules[__name__] = _pkg

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,6 @@
+"""Expose the ``src.integrations`` package at the top level."""
+from importlib import import_module
+import sys
+
+_pkg = import_module("src.integrations")
+sys.modules[__name__] = _pkg

--- a/output/__init__.py
+++ b/output/__init__.py
@@ -1,0 +1,6 @@
+"""Expose the ``src.output`` package at the top level."""
+from importlib import import_module
+import sys
+
+_pkg = import_module("src.output")
+sys.modules[__name__] = _pkg

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath =
+    .
+    src

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,15 +1,8 @@
 """Core helpers for the PDF to Access application."""
+from __future__ import annotations
+
 from .config import ConfigError, load_config
 from .extraction import extract_from_pdf, find_value_in_blocks, read_pdf_text_blocks
-from .workflow import (
-    NoApprovedRowsError,
-    NoInputFilesError,
-    ReviewFileMissingError,
-    WorkflowError,
-    ExtractionSummary,
-    UploadSummary,
-    WorkflowService,
-)
 
 __all__ = [
     "ConfigError",
@@ -25,3 +18,41 @@ __all__ = [
     "UploadSummary",
     "WorkflowService",
 ]
+
+
+# Lazy imports -----------------------------------------------------------------
+
+def __getattr__(name: str):
+    if name in {
+        "NoApprovedRowsError",
+        "NoInputFilesError",
+        "ReviewFileMissingError",
+        "WorkflowError",
+        "ExtractionSummary",
+        "UploadSummary",
+        "WorkflowService",
+    }:
+        from .workflow import (  # noqa: WPS433 - imported lazily to avoid heavy deps
+            ExtractionSummary,
+            NoApprovedRowsError,
+            NoInputFilesError,
+            ReviewFileMissingError,
+            UploadSummary,
+            WorkflowError,
+            WorkflowService,
+        )
+
+        return {
+            "NoApprovedRowsError": NoApprovedRowsError,
+            "NoInputFilesError": NoInputFilesError,
+            "ReviewFileMissingError": ReviewFileMissingError,
+            "WorkflowError": WorkflowError,
+            "ExtractionSummary": ExtractionSummary,
+            "UploadSummary": UploadSummary,
+            "WorkflowService": WorkflowService,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - used for tooling
+    return sorted(__all__)

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,6 @@
+"""Expose the ``src.ui`` package at the top level."""
+from importlib import import_module
+import sys
+
+_pkg = import_module("src.ui")
+sys.modules[__name__] = _pkg


### PR DESCRIPTION
## Summary
- expose the src packages (`core`, `integrations`, `output`, `ui`) at the repository root so they can be imported without installing the project
- update the `core` package to lazily import workflow helpers and avoid optional dependencies during import
- configure pytest to add the project root and `src` directory to `sys.path`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3d586a7e88330be77cce58857ebbc